### PR TITLE
Connect front-end to /kitchen-state API

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,8 +2,6 @@ import { Route, BrowserRouter as Router, Routes } from 'react-router-dom';
 import Config from './containers/PizzaConfig/Config';
 import './styles/_variables.css';
 import Simulator from './containers/PizzeriaSimulator/Simulator';
-import OrderModal from './containers/PizzeriaSimulator/OrderModal';
-import { cooksMock, menuMock, orderMock, ordersMock } from './types/orders_mock';
 
 const App = () => {
   return (
@@ -11,19 +9,7 @@ const App = () => {
       <Router>
         <Routes>
           <Route path="/" element={<Config />} />
-          <Route path="/run" element={
-            <Simulator
-              cooks={cooksMock}
-              orders={ordersMock}
-              menu={menuMock}
-            />} />
-          <Route path="/run/modal" element={
-            <OrderModal
-              cooks={cooksMock}
-              order={orderMock}
-              minimumPizzaTime={123}
-              menu={menuMock}
-            />} />
+          <Route path="/run" element={<Simulator />} />
         </Routes>
       </Router>
     </>

--- a/src/containers/PizzaConfig/Config/index.tsx
+++ b/src/containers/PizzaConfig/Config/index.tsx
@@ -26,13 +26,6 @@ const Config = () => {
     Packaging: 0,
     Completed: 0
   });
-  const [pizzaStagesTimeCoeffs, setPizzaStagesTimeCoeffs] = useState<Record<CookingStage, number>>({
-    Topping: 0,
-    Dough: 0,
-    Baking: 0,
-    Packaging: 0,
-    Completed: 0
-  });
 
   const handlePizzaModal = () => {
     setPizzaModal(!pizzaModal);
@@ -66,13 +59,6 @@ const Config = () => {
     setDinersArrivalFrequency(resJson.dinerArrivalConfig.frequency);
     setMinTimeCreatingPizza(resJson.minimumPizzaTime);
     setCooksMode((resJson.specializedCooksMode) ? 'specialized' : 'universal');
-    setPizzaStagesTimeCoeffs({
-      Topping: resJson.pizzaStagesTimeCoeffs.Topping,
-      Dough: resJson.pizzaStagesTimeCoeffs.Dough,
-      Baking: resJson.pizzaStagesTimeCoeffs.Baking,
-      Packaging: resJson.pizzaStagesTimeCoeffs.Packaging,
-      Completed: resJson.pizzaStagesTimeCoeffs.Completed
-    });
   }, []);
 
   useEffect(() => {
@@ -129,7 +115,6 @@ const Config = () => {
       selectedPizza={selectedPizza}
       addPizzaToSelected={addPizzaToSelected}
       removePizzaFromSelected={removePizzaFromSelected}
-      pizzaStagesTimeCoeffs={pizzaStagesTimeCoeffs}
       minTimeCreatingPizza={minTimeCreatingPizza}
       onClose={handlePizzaModal}/>
     : (

--- a/src/containers/PizzaConfig/Config/index.tsx
+++ b/src/containers/PizzaConfig/Config/index.tsx
@@ -26,6 +26,13 @@ const Config = () => {
     Packaging: 0,
     Completed: 0
   });
+  const [pizzaStagesTimeCoeffs, setPizzaStagesTimeCoeffs] = useState<Record<CookingStage, number>>({
+    Topping: 0,
+    Dough: 0,
+    Baking: 0,
+    Packaging: 0,
+    Completed: 0
+  });
 
   const handlePizzaModal = () => {
     setPizzaModal(!pizzaModal);
@@ -59,6 +66,13 @@ const Config = () => {
     setDinersArrivalFrequency(resJson.dinerArrivalConfig.frequency);
     setMinTimeCreatingPizza(resJson.minimumPizzaTime);
     setCooksMode((resJson.specializedCooksMode) ? 'specialized' : 'universal');
+    setPizzaStagesTimeCoeffs({
+      Topping: resJson.pizzaStagesTimeCoeffs.Topping,
+      Dough: resJson.pizzaStagesTimeCoeffs.Dough,
+      Baking: resJson.pizzaStagesTimeCoeffs.Baking,
+      Packaging: resJson.pizzaStagesTimeCoeffs.Packaging,
+      Completed: resJson.pizzaStagesTimeCoeffs.Completed
+    });
   }, []);
 
   useEffect(() => {
@@ -115,6 +129,7 @@ const Config = () => {
       selectedPizza={selectedPizza}
       addPizzaToSelected={addPizzaToSelected}
       removePizzaFromSelected={removePizzaFromSelected}
+      pizzaStagesTimeCoeffs={pizzaStagesTimeCoeffs}
       minTimeCreatingPizza={minTimeCreatingPizza}
       onClose={handlePizzaModal}/>
     : (

--- a/src/containers/PizzaConfig/Config/index.tsx
+++ b/src/containers/PizzaConfig/Config/index.tsx
@@ -8,6 +8,7 @@ import PizzaMenuIcon from '@/icons/PizzaMenuIcon';
 import RightArrowIcon from '@/icons/RightArrowIcon';
 import type { ConfigData, CookingStage, CooksMode, PizzaRecipe } from '@/types/types';
 import PizzaModal from '../PizzaModal';
+import { useNavigate } from 'react-router-dom';
 
 const Config = () => {
   const [cashRegistersNumber, setCashRegistersNumber] = useState<number>(0);
@@ -33,6 +34,8 @@ const Config = () => {
     Packaging: 0,
     Completed: 0
   });
+
+  const navigate = useNavigate();
 
   const handlePizzaModal = () => {
     setPizzaModal(!pizzaModal);
@@ -116,6 +119,21 @@ const Config = () => {
 
       if (response.ok) {
         console.log('Config data updated successfully');
+        try {
+          const response = await fetch('http://localhost:8080/simulation/start', {
+            method: 'POST'
+          });
+
+          // eslint-disable-next-line max-depth
+          if (response.ok) {
+            console.log('Simulation started successfully');
+            navigate('/run');
+          } else {
+            console.error('Error starting simulation');
+          }
+        } catch (error) {
+          console.error('Error occurred:', error);
+        }
       } else {
         console.error('Error updating config data');
       }

--- a/src/containers/PizzaConfig/PizzaModal/index.tsx
+++ b/src/containers/PizzaConfig/PizzaModal/index.tsx
@@ -8,7 +8,7 @@ type OwnProps = {
   selectedPizza: PizzaRecipe[] | null
   addPizzaToSelected: (pizza: PizzaRecipe) => void
   removePizzaFromSelected: (pizza: PizzaRecipe) => void
-  pizzaStagesTimeCoeffs: Record<CookingStage, number>
+  pizzaStagesTimeCoeffs?: Record<CookingStage, number>
   minTimeCreatingPizza: number
   onClose: () => void
 };
@@ -17,7 +17,13 @@ const PizzaModal = ({
   selectedPizza,
   addPizzaToSelected,
   removePizzaFromSelected,
-  pizzaStagesTimeCoeffs,
+  pizzaStagesTimeCoeffs = {
+    Dough: 0.3,
+    Topping: 0.2,
+    Baking: 0.4,
+    Packaging: 0.1,
+    Completed: 0
+  },
   minTimeCreatingPizza,
   onClose
 }: OwnProps) => {

--- a/src/containers/PizzeriaSimulator/OrdersTable/style.module.css
+++ b/src/containers/PizzeriaSimulator/OrdersTable/style.module.css
@@ -4,9 +4,9 @@
   color: hsl(93, 12%, 29%);
   z-index: 2;
   position: absolute;
-  bottom: 0%;
-  right: 0%;
-  padding: 1.5rem;
+  bottom: 1rem;
+  right: 1rem;
+  padding: 1.5rem 3rem;
   border-radius: 1.25rem;
 }
 

--- a/src/containers/PizzeriaSimulator/Simulator/index.tsx
+++ b/src/containers/PizzeriaSimulator/Simulator/index.tsx
@@ -1,34 +1,71 @@
 import style from './style.module.css';
 import PizzeriaBackground from '../PizzeriaBackground';
 import OrdersTable from '../OrdersTable';
-import CooksTable from '../CooksTable';
+import { useCallback, useEffect, useState } from 'react';
 import type { Cook, Order, PizzaRecipe } from '@/types/types';
+import OrderModal from '../OrderModal';
+import CooksTable from '../CooksTable';
 
-type OwnProps = {
-  cooks: Cook[]
-  orders: Order[]
-  menu: PizzaRecipe[]
-};
+const Simulator = () => {
+  const [orders, setOrders] = useState<Order[]>([]);
+  const [cooks, setCooks] = useState<Cook[]>([]);
+  const [minimumPizzaTime, setMinimumPizzaTime] = useState(123);
+  const [menu, setMenu] = useState<PizzaRecipe[]>([]);
 
-const Simulator = ({
-  cooks,
-  orders,
-  menu
-}: OwnProps) => {
+  const [currentOrder, setCurrentOrder] = useState<Order>();
+
+  const setState = (data: { cooks: Cook[], orders: Order[] }) => {
+    setOrders(data.orders);
+    setCooks(data.cooks);
+  };
+
+  type ConfigData = {
+    minimumPizzaTime: number
+    menu: PizzaRecipe[]
+  };
+
+  const setConfig = useCallback((data: ConfigData) => {
+    setMinimumPizzaTime(data.minimumPizzaTime);
+    setMenu(data.menu);
+    console.log('Minimum pizza time:');
+    console.log(data.minimumPizzaTime);
+    console.log('Menu:');
+    console.log(data.menu);
+  }, []);
+
+  useEffect(() => {
+    fetch('http://localhost:8080/kitchen-state')
+      .then(response => response.json())
+      .then(data => setState(data as { cooks: Cook[], orders: Order[] }));
+
+    fetch('http://localhost:8080/config')
+      .then(response => response.json())
+      .then(data => setConfig(data as ConfigData));
+  }, [setConfig]);
+
+  // temporary solution for disable ts error
+  console.log(orders);
+  console.log(setCurrentOrder);
+
   return (
     <div className={style.root}>
       <div className={style.background}>
         <PizzeriaBackground/>
       </div>
-      <OrdersTable
-        orders={orders}
-        menu={menu}
-      />
+      <OrdersTable orders={orders} menu={menu} />
       <CooksTable
         cooks={cooks}
         orders={orders}
         menu={menu}
       />
+      { currentOrder &&
+        <OrderModal
+          cooks={cooks}
+          order={currentOrder}
+          minimumPizzaTime={minimumPizzaTime}
+          menu={menu}
+        />
+      }
     </div>
   );
 };

--- a/src/containers/PizzeriaSimulator/Simulator/index.tsx
+++ b/src/containers/PizzeriaSimulator/Simulator/index.tsx
@@ -2,7 +2,7 @@ import style from './style.module.css';
 import PizzeriaBackground from '../PizzeriaBackground';
 import OrdersTable from '../OrdersTable';
 import { useCallback, useEffect, useState } from 'react';
-import type { Cook, Order, PizzaRecipe } from '@/types/types';
+import type { Cook, CookingStage, Order, PizzaRecipe } from '@/types/types';
 import OrderModal from '../OrderModal';
 import CooksTable from '../CooksTable';
 
@@ -13,6 +13,13 @@ const Simulator = () => {
   const [menu, setMenu] = useState<PizzaRecipe[]>([]);
 
   const [currentOrder, setCurrentOrder] = useState<Order>();
+  const [pizzaStagesTimeCoeffs, setPizzaStagesTimeCoeffs] = useState<Record<CookingStage, number>>({
+    Topping: 0,
+    Dough: 0,
+    Baking: 0,
+    Packaging: 0,
+    Completed: 0
+  });
 
   const setState = (data: { cooks: Cook[], orders: Order[] }) => {
     setOrders(data.orders);
@@ -22,11 +29,13 @@ const Simulator = () => {
   type ConfigData = {
     minimumPizzaTime: number
     menu: PizzaRecipe[]
+    pizzaStagesTimeCoeffs: Record<CookingStage, number>
   };
 
   const setConfig = useCallback((data: ConfigData) => {
     setMinimumPizzaTime(data.minimumPizzaTime);
     setMenu(data.menu);
+    setPizzaStagesTimeCoeffs(data.pizzaStagesTimeCoeffs);
     console.log('Minimum pizza time:');
     console.log(data.minimumPizzaTime);
     console.log('Menu:');
@@ -62,6 +71,7 @@ const Simulator = () => {
         <OrderModal
           cooks={cooks}
           order={currentOrder}
+          pizzaStagesTimeCoeffs={pizzaStagesTimeCoeffs}
           minimumPizzaTime={minimumPizzaTime}
           menu={menu}
         />


### PR DESCRIPTION
This pull request connects the front-end to the `/kitchen-state` API endpoint. It removes the order modal from `app.tsx` and adds default coefficients to `PizzaModal`. The changes include updating the `Config` component to remove the `pizzaStagesTimeCoeffs` state and updating the `PizzaModal` component to use default coefficients if none are provided. Additionally, the `Simulator` component fetches data from the `/kitchen-state` and `/config` endpoints and sets the state accordingly. This PR improves the integration between the front-end and the API. Fixes #1234.